### PR TITLE
Place marker to client location when creating a new issue

### DIFF
--- a/frontend/js/components/locationControl.js
+++ b/frontend/js/components/locationControl.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import L from 'leaflet';
+import { MapControl } from 'react-leaflet';
+
+export default class LocationControl extends MapControl {  // note we're extending MapControl from react-leaflet, not Component from react
+
+  locateMe() {
+    console.log('Locate!',arguments);
+  }
+
+  componentWillMount() {
+    const locationControl = L.control({position: 'topleft'});  // see http://leafletjs.com/reference.html#control-positions for other positions
+    const jsx = (
+      <a href='#' onClick={this.props.locate}>
+        Locate Me!
+      </a>
+    );
+
+    locationControl.onAdd = function (map) {
+      let div = L.DomUtil.create('div', '');
+      ReactDOM.render(jsx, div);
+      return div;
+    };
+
+    this.leafletElement = locationControl;
+  }
+}

--- a/frontend/js/components/map.js
+++ b/frontend/js/components/map.js
@@ -8,6 +8,7 @@ import { browserHistory } from 'react-router'
 import { setCoordinates } from '../actions'
 import getMarkerForIssue from './markers/markers';
 import LocationControl from './locationControl';
+import { defaultMapBounds } from '../globals';
 
 require('leaflet/dist/leaflet.css');
 
@@ -67,7 +68,6 @@ class AddNewMarker extends React.Component {
 }
 
 
-const europeBounds = [[57.64, -10.44], [36.81, 44.98]]
 export class LeafletMap extends React.Component {
 
     constructor (props) {
@@ -155,7 +155,7 @@ export class LeafletMap extends React.Component {
         })
 
         let bounds = this._computeBounds(geojson)
-        
+
         return (
             <Map center={center}
                  bounds={bounds}
@@ -184,7 +184,7 @@ export class LeafletMap extends React.Component {
     _computeBounds(geojson) {
         let extents = geojsonExtent(Object.assign({}, geojson));
         if (extents == null) {
-            return europeBounds
+            return defaultMapBounds;
         }
         let point1 = extents.slice(0, 2).reverse()
         let point2 = extents.slice(2, 4).reverse()

--- a/frontend/js/globals.js
+++ b/frontend/js/globals.js
@@ -1,0 +1,6 @@
+export const defaultMapBounds = [[57.64, -10.44], [36.81, 44.98]];
+
+export const defaultIssueLocation = {
+  lng: 16.369620,
+  lat:48.2092563
+};

--- a/frontend/js/location_selector.js
+++ b/frontend/js/location_selector.js
@@ -11,14 +11,26 @@ require('leaflet/dist/leaflet.css');
 class B2SelectorMap extends React.Component {
   constructor(props) {
     super(props)
+    this._map = null
     this.state = { position: this.props.position || defaultIssueLocation }
+
     this.onPositionChange = this.onPositionChange.bind(this);
+    this.handleLocationFound = this.handleLocationFound.bind(this);
+    this.handleLocationError = this.handleLocationError.bind(this);
   }
 
   componentDidMount() {
-    if ("geolocation" in navigator) {
-      navigator.geolocation.getCurrentPosition((p) => this.setPosition({ lng: p.coords.longitude, lat: p.coords.latitude }));
+    if (this.state.position === defaultIssueLocation) {
+      this._map.getLeafletElement().locate();
     }
+  }
+
+  handleLocationFound(e) {
+    this.setPosition(e.latlng);
+  }
+
+  handleLocationError() {
+    this.setPosition(defaultIssueLocation);
   }
 
   setPosition(position) {
@@ -53,7 +65,8 @@ class B2SelectorMap extends React.Component {
     }
 
     return (
-      <Map center={position} onClick={(e) => this.onPositionChange(e.latlng)} zoom={12}>
+      <Map center={position} onClick={(e) => this.onPositionChange(e.latlng)} zoom={12} ref={(m) => this._map = m}
+            onLocationfound={this.handleLocationFound} onLocationerror={this.handleLocationError} >
         <TileLayer url='//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
                    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors' />
                  {marker}

--- a/frontend/js/location_selector.js
+++ b/frontend/js/location_selector.js
@@ -6,13 +6,24 @@ import { Map, Marker, Popup, TileLayer, Circle } from 'react-leaflet';
 
 require('leaflet/dist/leaflet.css');
 
+const vienna = {lng: 16.369620, lat:48.2092563};
 class B2SelectorMap extends React.Component {
   constructor(props) {
     super(props)
-    this.state = {
-      position: this.props.position
-    }
+    this.state = { position: this.props.position || vienna }
     this.onPositionChange = this.onPositionChange.bind(this);
+  }
+
+  componentDidMount() {
+    if ("geolocation" in navigator) {
+      navigator.geolocation.getCurrentPosition((p) => this.setPosition({ lng: p.coords.longitude, lat: p.coords.latitude }));
+    }   
+  }
+
+  setPosition(position) {
+    this.setState({
+      position: position
+    });
   }
 
   onPositionChange(latLng) {
@@ -41,7 +52,7 @@ class B2SelectorMap extends React.Component {
     }
 
     return (
-      <Map center={this.props.position || {lng: 16.369620, lat:48.2092563}} onClick={(e) => this.onPositionChange(e.latlng)} zoom={12}>
+      <Map center={position} onClick={(e) => this.onPositionChange(e.latlng)} zoom={12}>
         <TileLayer url='//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
                    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors' />
                  {marker}

--- a/frontend/js/location_selector.js
+++ b/frontend/js/location_selector.js
@@ -4,20 +4,21 @@ import React, {PropTypes} from 'react';
 import { render } from 'react-dom';
 import { Map, Marker, Popup, TileLayer, Circle } from 'react-leaflet';
 
+import { defaultIssueLocation } from './globals';
+
 require('leaflet/dist/leaflet.css');
 
-const vienna = {lng: 16.369620, lat:48.2092563};
 class B2SelectorMap extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { position: this.props.position || vienna }
+    this.state = { position: this.props.position || defaultIssueLocation }
     this.onPositionChange = this.onPositionChange.bind(this);
   }
 
   componentDidMount() {
     if ("geolocation" in navigator) {
       navigator.geolocation.getCurrentPosition((p) => this.setPosition({ lng: p.coords.longitude, lat: p.coords.latitude }));
-    }   
+    }
   }
 
   setPosition(position) {


### PR DESCRIPTION
Resolves #14.

This pull request determines the client's location via the [geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation) and places the marker to that location when creating a new issue. If the user declines the permission to share the location, the marker is placed in the middle of Vienna.

@mcallistersean Please review