### PR TITLE
Use "notification rule" in wordings consistently

### DIFF
--- a/user_profile/models.py
+++ b/user_profile/models.py
@@ -69,7 +69,7 @@ class NotificationSettings(TimeStampedModel):
         return notification.send_issue_notification()
 
     def __str__(self):
-        return 'Notification filter of user: %s' %(self.user.username)
+        return 'Notification rule of user: %s' %(self.user.username)
 
     class Meta:
         ordering = ('-created',)

--- a/user_profile/templates/user_profile/notification/create.html
+++ b/user_profile/templates/user_profile/notification/create.html
@@ -2,7 +2,7 @@
 {% load i18n bootstrap3 %}
 
 {% block profile-title %}
-    {% trans 'Create new notification filter' %}
+    {% trans 'Create new notification rule' %}
 {% endblock %}
 
 {% block content %}

--- a/user_profile/templates/user_profile/notification/delete.html
+++ b/user_profile/templates/user_profile/notification/delete.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% block content %}
 <form method="post">
-  <p>{% trans 'Are you sure that you want to delete this notification filter?' %}</p>
+  <p>{% trans 'Are you sure that you want to delete this notification rule?' %}</p>
   <button type="submit" class="btn btn-danger">{% trans 'Yes, delete'%}</button>
 </form>
 {% endblock %}

--- a/user_profile/templates/user_profile/notification/edit.html
+++ b/user_profile/templates/user_profile/notification/edit.html
@@ -2,5 +2,5 @@
 {% load i18n bootstrap3 %}
 
 {% block profile-title %}
-    {% trans 'Edit notification filter' %}
+    {% trans 'Edit notification rule' %}
 {% endblock %}

--- a/user_profile/templates/user_profile/private.html
+++ b/user_profile/templates/user_profile/private.html
@@ -41,7 +41,7 @@
 
     {{ block.super }}
 
-    <h2>{% trans 'Notification Filters' %}</h2>
+    <h2>{% trans 'Notification Rules' %}</h2>
     <hr />
     {% if notification_settings|length %}
     <table class="table table-striped">
@@ -87,7 +87,7 @@
     <p class="text-muted">
         {% blocktrans %}
             You have no notifications configured.
-            Add your first notification filter to be notified when something happens around you.
+            Add your first notification rule to be notified when something happens around you.
         {% endblocktrans %}
     </p>
     {% endif %}


### PR DESCRIPTION
Fixes #17.

Isabella and I thought that "rule" would be slightly easier to understand than "filter" since a filter might suggest that you would receive fewer notifications if you create one. Currently we're mixing the terms. We should at least be consistent about it.