### PR TITLE
Make marker color represent issue status

### DIFF
--- a/frontend/css/bs-themes/flatly/_variables.scss
+++ b/frontend/css/bs-themes/flatly/_variables.scss
@@ -16,10 +16,10 @@ $gray-light:             #b4bcc2 !default;   // #999
 $gray-lighter:           #ecf0f1 !default; // #eee
 
 $brand-primary:         #2C3E50 !default;
-$brand-success:         #18BC9C !default;
+$brand-success:         #32A9DD !default;
 $brand-info:            #3498DB !default;
 $brand-warning:         #F39C12 !default;
-$brand-danger:          #E74C3C !default;
+$brand-danger:          #D32A19 !default;
 
 
 //== Scaffolding

--- a/frontend/js/components/markers/markers.js
+++ b/frontend/js/components/markers/markers.js
@@ -5,25 +5,22 @@ import getIconClassForIssueType from '../icons/issueType'
 require('Leaflet.extra-markers/src/assets/css/leaflet.extra-markers.css')
 let extraMarkers = require('Leaflet.extra-markers/src/assets/js/leaflet.extra-markers')
 
-const defaulIconProps = {
-    icon: 'fa-circle-o',
-    // marker colors
-    //'red', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'cyan', 'purple',
-    // 'violet', 'pink', 'green-dark', 'green', 'green-light', 'black', or 'white'
-    markerColor: 'blue',
-    //'circle', 'square', 'star', or 'penta'
-    shape: 'circle',
-    prefix: 'fa'
-}
 
 function getMarkerForIssue(issue={}, opts={}) {
-  let attribs = {}
-  attribs.icon = getIconClassForIssueType(issue.issue_type, 'fa-');
+  const defaulIconProps = {
+      icon: getIconClassForIssueType(issue.issue_type, 'fa-'),
+      // marker colors
+      //'red', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'cyan', 'purple',
+      // 'violet', 'pink', 'green-dark', 'green', 'green-light', 'black', or 'white'
+      markerColor: issue.status === 'closed' ? 'orange-dark' : 'cyan',
+      //'circle', 'square', 'star', or 'penta'
+      shape: 'circle',
+      prefix: 'fa'
+  }
 
   return Leaflet.ExtraMarkers.icon({
     ...defaulIconProps,
-    ...opts,
-    ...attribs
+    ...opts
   });
 }
 


### PR DESCRIPTION
Resolves #23.

This pull request...

 - Changes the bootstrap theme to use the same colors as used for the map markers
 - Uses a different marker color for closed issues