### PR TITLE
Redirect to home view with issue preselected after issue creation

### DIFF
--- a/issue_tracker/urls.py
+++ b/issue_tracker/urls.py
@@ -23,8 +23,9 @@ if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
 
 urlpatterns += [
+    url(r'^issue/(?P<issue_id>\d+)', HomeView.as_view(), name='home_issue'),
     # keep this at the bottom as it eats urls!
-    url(r'^', HomeView.as_view(), name='home'),
+    url(r'^', HomeView.as_view(), name='home')
 ]
 
 

--- a/issues/views.py
+++ b/issues/views.py
@@ -124,7 +124,7 @@ class IssueCreateView(LoginRequiredMixin, FormValidMessageMixin, CreateView):
 
     def get_success_url(self):
         return reverse(
-            'issues:issue_detail',
+            'home_issue',
             kwargs={'issue_id': self.object.pk},
             current_app=self.request.resolver_match.namespace
         )


### PR DESCRIPTION
In my opinion it's more intuitive if we redirect the user to issue view of the home page after the creation of the issue. What do you think?