### PR TITLE
Don't change zoom level when selecting an issue from the issue list

### DIFF
--- a/frontend/js/components/map.js
+++ b/frontend/js/components/map.js
@@ -81,7 +81,6 @@ export class LeafletMap extends React.Component {
         this.state = {
           context: false,
           center: null,
-          zoom: 10
         }
 
         // bind event handlers


### PR DESCRIPTION
When clicking an issue from the issue list, the zoom level of the map is currently changed to 10. The map should maintain the zoom level and just center the map to the selected issue.